### PR TITLE
Added centos6 container for builds

### DIFF
--- a/docker/centos6-py27-gcc44/Dockerfile
+++ b/docker/centos6-py27-gcc44/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:6
+
+MAINTAINER Brian Van Klaveren <bvan@slac.stanford.edu>
+
+RUN yum update -y && \
+   yum install -y epel-release centos-release-scl-rh && \
+   yum install -y curl gcc gcc-c++ scons \
+   freetype-devel libX11-devel libXt-devel openmotif-devel \
+   libXcursor-devel mesa-libGL-devel libGLU-devel \
+   libXrandr-devel libtiff-devel \
+   xrootd-client python27 rh-git29-git
+
+WORKDIR /workspace
+WORKDIR /ext
+
+RUN echo -e "#!/bin/bash\nsource scl_source enable python27 rh-git29" > /etc/profile.d/fermilat.sh


### PR DESCRIPTION
This adds a new centos6 build container.
This container is meant to be a starting point for Jenkins integration. It installs SCL versions of Python and git as well, and enables them so they should be the default whenever a container starts up.